### PR TITLE
Restore possibility to use anchors

### DIFF
--- a/mk_docs.py
+++ b/mk_docs.py
@@ -18,29 +18,30 @@ pymd = markdown.Markdown(extensions=md_ext, tab_length=2)
 # - add header, navigation and footer to the converted file
 def md2html(md_file, html_file, file_name):
     print("Transforming " + md_file + " into " + html_file)
-    
+
     with open(md_file, 'r') as f:
        text = f.read()
 
        html = pymd.convert(text)
        soup = BeautifulSoup(html, 'html.parser')
        for a in soup.findAll('a'):
-         
+
          if not a['href'].startswith(('http://', 'https://', '#')):
            parts = a['href'].split('#')
            if not parts[0].endswith(('html')):
-              a['href'] = parts[0]+".html"
-	   if (len(parts) > 1):
-	      a['href'] = a['href'] + '#' + parts[1]
-       
+             a['href'] = parts[0]+".html"
+
+           if (len(parts) > 1):
+             a['href'] = a['href'] + '#' + parts[1]
+
            if (str(a['href']).find(":") > 0):
              a['href'] = a['href'].replace(":", "/")
-       
+
        # TODO: At this point we could use title and description to auto generate a breadcrum or an index
        #title = soup.find('h1').string
        #if (len(title.split(":")) > 1):
        #  title = title.split(":")[1]
-       
+
        #desc = ""
        #p = soup.find('p')
        #if not p is None:
@@ -51,7 +52,7 @@ def md2html(md_file, html_file, file_name):
 
 # search a filesystem directory for subdirs and retum these in a list
 def getsubdirs(dir_path):
-	return(glob.glob(dir_path + '*/'))
+    return(glob.glob(dir_path + '*/'))
 
 # search a filesystem directory for markdown (md) files and parse these into html using the md2html function
 def parsefiles(docsdir, outputdir):
@@ -74,22 +75,22 @@ def parsefiles(docsdir, outputdir):
 # filter out the ones that do not have a ssp module
 def getmodulerepos():
     module_repos = []
-    
+
     with urllib.request.urlopen("https://api.github.com/users/simplesamlphp/repos?per_page=100") as url:
        repos = json.loads(url.read().decode())
-    
+
     for repo in repos:
       a_repo = {"name": [], "description": [], "html_url": [], "short_name": []}
-	
-      # we assume all module will have a name that starts with 'simplesamlphp-module-' 
+
+      # we assume all module will have a name that starts with 'simplesamlphp-module-'
       if (repo['name'].find('simplesamlphp-module-') == 0 and not repo['archived']):
         a_repo['name'] = str(repo['name'])
         a_repo['description'] = str(repo['description'])
         a_repo['html_url'] = str(repo['html_url'])
         a_repo['short_name'] = a_repo['name'].split("-")[2]
 
-        module_repos.append(a_repo)       
-    
+        module_repos.append(a_repo)
+
     return module_repos
 
 # clone a specific git repo to a given directory. Optionally fetch specific version
@@ -97,15 +98,15 @@ def getmodulerepos():
 def getgitrepo(repo, repo_clone_dir, repo_root, version=None):
    os.makedirs(os.path.join(repo_clone_dir))
    os.chdir(repo_clone_dir)
-   
+
    if (version is None or version == 'devel'):
       os.system('git clone --depth=1 ' + repo)
    else:
       os.system('git clone --depth=1 --branch simplesamlphp-' + version + ' ' + repo)
    os.chdir(repo_clone_dir + repo_root)
-   
+
    print("Working in git repo from" + os.getcwd())
-   
+
    os.system('git status')
 
 # make the header and headerbad div contents for indjection into each documentation page
@@ -140,14 +141,14 @@ def mkContentHeader(versions):
     content += '</nav>'
     content += '<div id="content">'
     content += '</header>'
-   
-    s = BeautifulSoup(content, 'html.parser')   
-   
+
+    s = BeautifulSoup(content, 'html.parser')
+
     return s.prettify()
 
-# make a navigation structure based on the versions we have doucmentation for    
+# make a navigation structure based on the versions we have doucmentation for
 def mkNavigation(versions):
-    
+
     #content = '<div id="langbar" style="clar: both"><div id="navigation">Documentation is available for the following versions: '
     #for version in versions:
     #    content += '<a href="/docs/'+version+'/index.html">'+version+'</a> | '
@@ -158,24 +159,24 @@ def mkNavigation(versions):
        if version == 'devel':
           content += '<div class="menuitem first">'
        else:
-          content += '<div class="menuitem">'  
+          content += '<div class="menuitem">'
 
        content += '<a href="'+site_base_path+version+'/index.html">'+version
        if version == versions[0]:
           content += ' (stable)'
        content += '</a></div>'
-    
+
     content += ' <div class="menuitem last">'
     content += '   <a href="' + site_base_path + 'contributed_modules.html"> Contributed modules</a>'
     content += ' </div>'
-    
+
     content += '</div>'
-    
+
     return content
 
 # make sure some resources are put in the right place for the website
 def mkResources(root_dir, web_root):
-    # starter index.html (just a redirect to 'stable')    
+    # starter index.html (just a redirect to 'stable')
     os.system('cp ' +  root_dir + 'resources/index.html ' + web_root + 'index.html ')
 
 # Builds an index.md file of all the contributed repository documetation (if available)
@@ -184,20 +185,20 @@ def mkcontribmodsindex(contrib_mods, module_index_file, contrib_mods_files):
     module_index += "===========================\n\n"
 
     pages = {}
-    
+
     for page in contrib_mods_files:
       s = page.split("/")
       mod_name = s[len(s) -2]
       page_name = s[len(s) -1]
-  
+
       if mod_name not in pages.keys():
         pages[mod_name] = []
 
       pages[mod_name].append(page_name)
-    
+
     for module in contrib_mods:
       module_index += " * "+ module["name"]  + "\n"
-      
+
       if module["description"] is not None:
          module_index += ": " + module["description"] + "\n"
 
@@ -207,30 +208,30 @@ def mkcontribmodsindex(contrib_mods, module_index_file, contrib_mods_files):
         for page in pages[module["short_name"]]:
           module_index += "   * Documentation: ["+ page + "](contrib_modules/"+ module["short_name"] + "/" + page +")\n"
       except KeyError:
-		# some modules do not have documentation, just ignore them      
+		# some modules do not have documentation, just ignore them
         pass
-      
+
     with open(module_index_file, 'w+') as f:
        f.write(module_index)
 
 # reads files and (sub)dirs from a given directory
 def getListOfFiles(dirName):
-    # create a list of file and sub directories 
-    # names in the given directory 
+    # create a list of file and sub directories
+    # names in the given directory
     listOfFile = os.listdir(dirName)
     allFiles = list()
     # Iterate over all the entries
     for entry in listOfFile:
         # Create full path
         fullPath = os.path.join(dirName, entry)
-        # If entry is a directory then get the list of files in this directory 
+        # If entry is a directory then get the list of files in this directory
         if os.path.isdir(fullPath):
             allFiles = allFiles + getListOfFiles(fullPath)
         else:
             allFiles.append(fullPath)
-                
+
     return allFiles
-	
+
 ################################################
 #
 # MAIN
@@ -279,7 +280,7 @@ mkResources(runner_path, site_root_dir)
 for ssp_version in ssp_versions:
    print("Working on: " + ssp_version)
    #print("Repo Root: " + repo_root_dir)
-   
+
    version_dir = tempdir + ssp_version + "/"
    #print("Version dir: " + version_dir)
    getgitrepo('https://github.com/simplesamlphp/simplesamlphp.git', version_dir, repo_root_dir, ssp_version)
@@ -309,22 +310,22 @@ for module in contrib_mods:
     print("Working on: " + module["name"])
     contrib_mod_dir = tempdir + "contrib_modules/" + module["name"] + "/"
     contrib_mod_web_dir = site_root_dir + "contrib_modules" + "/"
-    
-    # We assume contributes modules live in the ssp repo and are named 'simplesamlphp-module-*' 
+
+    # We assume contributes modules live in the ssp repo and are named 'simplesamlphp-module-*'
     getgitrepo(module["html_url"], contrib_mod_dir, module["name"])
-    
+
     module_dir = os.path.join(contrib_mod_dir, module["name"], "docs/")
     print(module_dir)
-    
+
     if os.path.isdir(module_dir):
       module_output_dir = os.path.join(contrib_mod_web_dir, module["short_name"]+ "/")
       parsefiles(module_dir, module_output_dir)
-    
+
     else:
         print("No docs found for '" + module["name"] +"'")
-        
+
 # Now build an index of generated documents
-contrib_mods_files= getListOfFiles(site_root_dir + "contrib_modules" + "/")  
+contrib_mods_files= getListOfFiles(site_root_dir + "contrib_modules" + "/")
 mkcontribmodsindex(contrib_mods, module_index_file, contrib_mods_files)
 md2html(module_index_file, site_root_dir + 'contributed_modules.html', 'contributed_modules.html')
 

--- a/mk_docs.py
+++ b/mk_docs.py
@@ -27,8 +27,11 @@ def md2html(md_file, html_file, file_name):
        for a in soup.findAll('a'):
          
          if not a['href'].startswith(('http://', 'https://', '#')):
-           if not a['href'].endswith(('html')):
-              a['href'] = a['href']+".html"
+           parts = a['href'].split('#')
+           if not parts[0].endswith(('html')):
+              a['href'] = parts[0]+".html"
+	   if (len(parts) > 1):
+	      a['href'] = a['href'] + '#' + parts[1]
        
            if (str(a['href']).find(":") > 0):
              a['href'] = a['href'].replace(":", "/")

--- a/mk_docs.py
+++ b/mk_docs.py
@@ -29,7 +29,7 @@ def md2html(md_file, html_file, file_name):
          if not a['href'].startswith(('http://', 'https://', '#')):
            parts = a['href'].split('#')
            if not parts[0].endswith(('html')):
-             a['href'] = parts[0]+".html"
+             a['href'] = parts[0] + ".html"
 
            if (len(parts) > 1):
              a['href'] = a['href'] + '#' + parts[1]


### PR DESCRIPTION
Will translate `simplesamlphp-install#prerequisites` to `simplesamlphp-install.html#prerequisites` instead of the current `simplesamlphp-install#prerequisites.html`
This allows us to use anchors again.